### PR TITLE
Local path resolution

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -116,3 +116,4 @@ dependencies:
     - transformers==4.20.1
     - werkzeug==2.1.2
     - yarl==1.7.2
+    - mypy==0.961

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aitextgen
 tokenizers
+mypy

--- a/src/build_tokenizer.py
+++ b/src/build_tokenizer.py
@@ -60,7 +60,7 @@ class TokenizerConfig:
             json.dump({
                 'name': self.name,
                 'parent_dir': self.parent_dir.get_project_relative_path(),
-                'vocab_size': self.vocab_size.get_project_relative_path(),
+                'vocab_size': self.vocab_size,
                 'tokenizer_model_overview_file': self.tokenizer_model_overview_file.get_project_relative_path(),
                 'vocab_file': self.vocab_file.get_project_relative_path(),
                 'merges_file': self.merges_file.get_project_relative_path(),

--- a/src/build_tokenizer.py
+++ b/src/build_tokenizer.py
@@ -57,14 +57,18 @@ class TokenizerConfig:
         - out_path: Path to JSON file where contents will be stored
         """
         with open(out_path, 'w') as out_f:
-            json.dump({
-                'name': self.name,
-                'parent_dir': self.parent_dir.get_project_relative_path(),
-                'vocab_size': self.vocab_size,
-                'tokenizer_model_overview_file': self.tokenizer_model_overview_file.get_project_relative_path(),
-                'vocab_file': self.vocab_file.get_project_relative_path(),
-                'merges_file': self.merges_file.get_project_relative_path(),
-            }, out_f)
+            json.dump(
+                {
+                    'name': self.name,
+                    'parent_dir': self.parent_dir.get_project_relative_path(),
+                    'vocab_size': self.vocab_size,
+                    'tokenizer_model_overview_file': self.tokenizer_model_overview_file.get_project_relative_path(),
+                    'vocab_file': self.vocab_file.get_project_relative_path(),
+                    'merges_file': self.merges_file.get_project_relative_path(),
+                },
+                out_f,
+                indent=4,
+            )
 
     @staticmethod
     def load(load_path: LocalPath) -> 'TokenizerConfig':

--- a/src/encode_dataset.py
+++ b/src/encode_dataset.py
@@ -6,11 +6,10 @@ from typing import Optional, List
 from aitextgen.TokenDataset import TokenDataset
 
 import lib_logging
+from lib_path import LocalPath
 from build_tokenizer import TokenizerConfig
 
 logger = lib_logging.make_logger('encode-dataset')
-
-PROG_DIR = os.path.dirname(os.path.realpath(__file__))
 
 def parse_args():
     """ Parse command line arguments.
@@ -21,20 +20,20 @@ def parse_args():
     parser.add_argument(
         '--dataset-in',
         help="Path to training data input file",
-        type=str,
-        default=os.path.realpath(os.path.join(PROG_DIR, "../training-data/discord-messages.txt")),
+        type=LocalPath,
+        default=LocalPath("training-data/discord-messages.txt"),
     )
     parser.add_argument(
         '--dataset-out',
         help="Path to which encoded training data will be saved",
-        type=str,
-        default=os.path.realpath(os.path.join(PROG_DIR, "../training-data/discord-messages.tar.gz")),
+        type=LocalPath,
+        default=LocalPath("training-data/discord-messages.tar.gz"),
     )
     parser.add_argument(
         '--tokenizer-index',
         help="Path to tokenizer input file which specifies which tokenizer to use",
-        type=str,
-        default=os.path.realpath(os.path.join(PROG_DIR, "../training-data/tokenizer-index.json")),
+        type=LocalPath,
+        default=LocalPath("training-data/tokenizer-index.json"),
     )
 
     # Parse results
@@ -54,8 +53,8 @@ def main():
     )
 
 def encode_dataset(
-    dataset_in: str,
-    dataset_out: str,
+    dataset_in: LocalPath,
+    dataset_out: LocalPath,
     tokenizer_config: TokenizerConfig,
 ):
     """ Given a dataset encodes the contents using the tokenizer. Saves the results.
@@ -65,11 +64,11 @@ def encode_dataset(
     - tokenizer_config: Information about the tokenizer
     """
     TokenDataset(
-        file_path=dataset_in,
-        vocab_file=tokenizer_config.vocab_file,
-        merges_file=tokenizer_config.merges_file,
+        file_path=dataset_in.get_absolute_path(),
+        vocab_file=tokenizer_config.vocab_file.get_absolute_path(),
+        merges_file=tokenizer_config.merges_file.get_absolute_path(),
         save_cache=True,
-        cache_destination=dataset_out,
+        cache_destination=dataset_out.get_absolute_path(),
     )
 
 if __name__ == '__main__':

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-from typing import List
+from typing import List, Tuple
 
 from aitextgen import aitextgen
 
@@ -130,7 +130,7 @@ def print_results(
 
 def load_model(
     model_dir: LocalPath,
-) -> (aitextgen, TrainingMetadata):
+) -> Tuple[aitextgen, TrainingMetadata]:
     """ Loads a trained model from the file system.
     Arguments:
     - model_dir: The directory in which the model data resides

--- a/src/lib_path.py
+++ b/src/lib_path.py
@@ -32,7 +32,7 @@ class LocalPath:
     def get_absolute_path(self) -> str:
         """ Returns: Path relative to file system root.
         """
-        return return os.path.realpath(self.get_project_relative_path())
+        return os.path.realpath(self.get_project_relative_path())
 
     def join(self, parts: List[str]) -> LocalPath:
         """ Constructs a new LocalPath with parts added onto the end.

--- a/src/lib_path.py
+++ b/src/lib_path.py
@@ -5,31 +5,6 @@ from pathlib import PureWindowsPath, PurePosixPath
 PROG_DIR = os.path.dirname(os.path.realpath(__file__))
 REPO_DIR = os.path.realpath(os.path.join(PROG_DIR, ".."))
 
-class UnableToReconcileAbsPathError(Exception):
-    """ Indicates that an absolute path was received but it couldn't be turned into a relative path.
-    Specifically the following conditions must be met:
-    - an absolute path was received
-    - but that absolute path was determined not to be from this machine's file system
-    - and an effort was undertaken to strip the parts of the abolute path which were not from this machine's file system
-    - but not a single part of the absolute path was found to be from this project's directory structure
-
-    Fields:
-    - raw_path: The unprocessed path
-    - os_path: The path as represented by the pathlib primitive for the paths origin operating system
-    """
-    raw_path: str
-    os_path: Union[PurePosixPath, PureWindowsPath]
-
-    def __init__(self, raw_path: str, os_path: Union[PurePosixPath, PureWindowsPath]):
-        """ Initialize a UnabletoReconcileAbsPathError.
-        Arguments:
-        - raw_path: See UnableToReconcileAbsPathError.raw_path field
-        - os_path: See UnableToReconcileAbsPathError.os_path field
-        """
-        super().__init__(f"The absolute path '{raw_path}' was determined to not be from this device's file system and not from this project's directory structure")
-        self.raw_path = raw_path
-        self.os_path = os_path
-
 class LocalPath:
     """ Represents a file or directory path in the project directory.
     Fields:
@@ -43,9 +18,6 @@ class LocalPath:
         - parts: List of path parts, relative to the project root
 
         If parts happens to be an absolute path from another machine a best attempt is made to reconcile the path into something relative to the project's directory. This behavior exists because previous versions of the code saved absolute paths in metadata files, making them non-portable.
-
-        Raises:
-        - UnableToReconcileAbsPathError: If the absolute path cannot be reconciled, see error class documentation for more details
         """
         # Join parts together
         joined_parts = ""

--- a/src/lib_path.py
+++ b/src/lib_path.py
@@ -50,7 +50,7 @@ class LocalPath:
         # Join parts together
         joined_parts = ""
         if isinstance(parts, list):
-            joined_parts = os.path.join(parts)
+            joined_parts = os.path.join(*parts)
         else:
             joined_parts = parts
 

--- a/src/lib_path.py
+++ b/src/lib_path.py
@@ -1,0 +1,44 @@
+from typing import List, Union
+import os
+
+PROG_DIR = os.path.dirname(os.path.realpath(__file__))
+REPO_DIR = os.path.realpath(os.path.join(PROG_DIR, ".."))
+
+class LocalPath:
+    """ Represents a file or directory path in the project directory.
+    Fields:
+    - __project_relative_path: Path represented relative to the project directory root
+    """
+    __project_relative_path: str
+
+    def __init__(self, parts: Union[List[str], str]):
+        """ Initializes a LocalPath.
+        Arguments:
+        - parts: List of path parts, relative to the project root
+        """
+        parts_list = []
+        if isinstance(parts, list):
+            parts_list = parts
+        else:
+            parts_list = [ parts ]
+        
+        self.__project_relative_path = os.path.relpath(os.path.join(*parts_list), REPO_DIR)
+
+    def get_project_relative_path(self) -> str:
+        """ Returns: Path relative to the project root directory.
+        """
+        return self.__project_relative_path
+
+    def get_absolute_path(self) -> str:
+        """ Returns: Path relative to file system root.
+        """
+        return return os.path.realpath(self.get_project_relative_path())
+
+    def join(self, parts: List[str]) -> LocalPath:
+        """ Constructs a new LocalPath with parts added onto the end.
+        Arguments:
+        - parts: File path parts to append.
+
+        Returns: New LocalPath.
+        """
+        return LocalPath([self.get_project_relative_path(), *parts])

--- a/src/train.py
+++ b/src/train.py
@@ -50,6 +50,7 @@ class TrainingMetadata:
                     'tokenizer_index': self.tokenizer_index.get_project_relative_path(),
                 },
                 out_f,
+                indent=4,
             )
 
     @staticmethod

--- a/src/train.py
+++ b/src/train.py
@@ -16,9 +16,6 @@ from build_tokenizer import TokenizerConfig
 
 logger = lib_logging.make_logger('train')
 
-PROG_DIR = os.path.dirname(os.path.realpath(__file__))
-
-
 class TrainingMetadata:
     """ Holds metadata about the training progress of a model.
     Fields:
@@ -47,10 +44,13 @@ class TrainingMetadata:
         - out_file: Path to which JSON file will be saved
         """
         with open(out_file.get_absolute_path(), 'w') as out_f:
-            json.dump({
-                'training_iterations': self.training_iterations,
-                'tokenizer_index': self.tokenizer_index.get_project_relative_path(),
-            }, out_f)
+            json.dump(
+                {
+                    'training_iterations': self.training_iterations,
+                    'tokenizer_index': self.tokenizer_index.get_project_relative_path(),
+                },
+                out_f,
+            )
 
     @staticmethod
     def load(in_file: LocalPath) -> 'TrainingMetadata':


### PR DESCRIPTION
There was a regression in the code base where absolute paths are stored in the training metadata and tokenizer index files. This meant that these files couldn't be sent to others and used on their system. This PR introduced the `LocalPath` wrapper class which allows access to file paths relative to the project root and as an absolute path. The code was updated to use this class, and to never save an absolute path to one of the aforementioned JSON files. Additionally some logic was added to the `LocalPath` class to detect the absolute paths from other systems and to a best effort to resolve them on the new person's machine.